### PR TITLE
Don't skip redeployment

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -50,7 +50,6 @@ jobs:
   needs: docker
   name: Redeploy
   runs-on: strawberry
-  if: github.event_name == 'pull_request'
   steps:
    - name: Login to DockerHub
      uses: docker/login-action@v1


### PR DESCRIPTION
In the last PR where the CI job got changed, the redeployment part got skipped because it still contained the if statement to check if it was part of a PR - rather than a push to main